### PR TITLE
Fix calibration API url formats

### DIFF
--- a/pages/robot/tabs/calibrations/index.php
+++ b/pages/robot/tabs/calibrations/index.php
@@ -260,6 +260,9 @@ $open_calibration = "camera_intrinsic";
     
     function _load_info (calib_type) {
         let url = get_api_url('files', 'calibration/info', [calib_type]);
+        // get_api_url(...) appends '/' to URLs without query params
+        // for this endpoint, it needs to be removed
+        url = url.rstrip("/");
         function _on_success_fcn(data) {
             _on_info_success(calib_type, data);
         }
@@ -300,6 +303,8 @@ $open_calibration = "camera_intrinsic";
     
     function _load_backups (calib_type) {
         let url = get_api_url('files', 'calibration/backup/list', [calib_type]);
+        // see comments in: function _load_info(...)
+        url = url.rstrip("/")
         $('#{0}_{1}'.format([calib_type, 'backups_loader'])).css("display", "inline-block");
         function _on_success_fcn(data) {
             $('#{0}_{1}'.format([calib_type, 'backups_table'])).html("");

--- a/pages/robot/tabs/calibrations/index.php
+++ b/pages/robot/tabs/calibrations/index.php
@@ -321,6 +321,8 @@ $open_calibration = "camera_intrinsic";
     
     function _restore_backup (calib_type, origin) {
         let url = get_api_url('files', 'calibration/backup/restore', [calib_type, origin]);
+        // see comments in: function _load_info(...)
+        url = url.rstrip("/")
         callExternalAPI(
             url, 'GET', 'json', true, true
         );


### PR DESCRIPTION
The calibration tab shows `(error)` even with calibration `.yaml` file present. This PR tries to fix it.

### Before
![image](https://github.com/duckietown/compose-pkg-duckietown-duckiebot/assets/10885835/0d925fbc-5331-405f-a1bd-76f258e38281)

### After
![image](https://github.com/duckietown/compose-pkg-duckietown-duckiebot/assets/10885835/0288c007-a895-40d7-a35b-77289ef636e7)
