### PR TITLE
DTSW-7635-Update-Dashboard-for-DB26J-to-Enable-HW-Tests

### DIFF
--- a/modules/api/1.0/api-services/specifications/robot_settings.json
+++ b/modules/api/1.0/api-services/specifications/robot_settings.json
@@ -95,6 +95,7 @@
                                     "DB19",
                                     "DB21M",
                                     "DB21J",
+                                    "DB26J",
                                     "DBR",
                                     "DD18",
                                     "DD21",
@@ -117,13 +118,15 @@
                                 "values": [
                                     "raspberry_pi",
                                     "raspberry_pi_64",
-                                    "jetson_nano"
+                                    "jetson_nano",
+                                    "jetson_orin"
                                 ],
                                 "__form__": {
                                     "labels": [
                                         "Raspberry Pi",
                                         "Raspberry Pi 64",
-                                        "NVidia Jetson Nano"
+                                        "Nvidia Jetson Nano",
+                                        "Nvidia Jetson Orin"
                                     ]
                                 },
                                 "default": "raspberry_pi",


### PR DESCRIPTION
This pull request updates the `robot_settings.json` specification to expand supported robot models and hardware platforms. The most significant changes are the addition of a new robot model and new hardware support.

**Robot model updates:**
- Added `"DB26J"` to the list of supported robot models.

**Hardware platform updates:**
- Added support for `"jetson_orin"` in the list of hardware platforms, including its corresponding label `"Nvidia Jetson Orin"`.